### PR TITLE
fix completion if script has space in name

### DIFF
--- a/src/cleo/commands/completions/templates.py
+++ b/src/cleo/commands/completions/templates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 
+# language="Shell Script" # noqa: E800
 BASH_TEMPLATE = """\
 %(function)s()
 {
@@ -52,6 +53,7 @@ BASH_TEMPLATE = """\
 
 %(compdefs)s"""
 
+# language="Shell Script" # noqa: E800
 ZSH_TEMPLATE = """\
 #compdef %(script_name)s
 
@@ -101,6 +103,7 @@ ZSH_TEMPLATE = """\
 %(function)s "$@"
 %(compdefs)s"""
 
+# language="Shell Script" # noqa: E800
 FISH_TEMPLATE = """\
 function __fish%(function)s_no_subcommand
     for i in (commandline -opc)
@@ -120,6 +123,5 @@ end
 # command options
 
 %(cmds_opts)s"""
-
 
 TEMPLATES = {"bash": BASH_TEMPLATE, "zsh": ZSH_TEMPLATE, "fish": FISH_TEMPLATE}

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -26,7 +26,10 @@ class CompletionsCommand(Command):
     options = [
         helpers.option(
             "alias", None, "Alias for the current command.", flag=False, multiple=True
-        )
+        ),
+        helpers.option(
+            "function-name", None, "Name of the completion function.", flag=False
+        ),
     ]
 
     SUPPORTED_SHELLS = ("bash", "zsh", "fish")
@@ -291,6 +294,14 @@ script. Consult your shells documentation for how to add such directives.
         return os.path.basename(shell)
 
     def _generate_function_name(self, script_name: str, script_path: str) -> str:
+        if self.option("function-name"):
+            if self.option("function-name").startswith("_"):
+                return str(self.option("function-name"))
+            else:
+                raise ValueError(
+                    "The function name must start with an underscore (_). "
+                    "Please check the value of the --function-name option."
+                )
         sanitized_name = self._sanitize_for_function_name(script_name)
         md5_hash = hashlib.md5(script_path.encode()).hexdigest()[0:16]
         return f"_{sanitized_name}_{md5_hash}_complete"

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -141,7 +141,11 @@ script. Consult your shells documentation for how to add such directives.
 
     def render_bash(self) -> str:
         script_name, script_path = self._get_script_name_and_path()
-        aliases = [script_name, script_path, *self.option("alias")]
+        aliases = [
+            script_name,
+            self._quote_script_path_for_compdef(script_path),
+            *self.option("alias"),
+        ]
         function = self._generate_function_name(script_name, script_path)
 
         # Global options
@@ -183,7 +187,10 @@ script. Consult your shells documentation for how to add such directives.
 
     def render_zsh(self) -> str:
         script_name, script_path = self._get_script_name_and_path()
-        aliases = [script_path, *self.option("alias")]
+        aliases = [
+            self._quote_script_path_for_compdef(script_path),
+            *self.option("alias"),
+        ]
         function = self._generate_function_name(script_name, script_path)
 
         def sanitize(s: str) -> str:
@@ -291,6 +298,9 @@ script. Consult your shells documentation for how to add such directives.
         name = name.replace("-", "_")
 
         return re.sub("[^A-Za-z0-9_]+", "", name)
+
+    def _quote_script_path_for_compdef(self, script_path: str) -> str:
+        return shell_quote(script_path) if " " in script_path else script_path
 
     def _zsh_describe(self, value: str, description: str | None = None) -> str:
         value = '"' + value.replace(":", "\\:")

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -188,6 +188,7 @@ script. Consult your shells documentation for how to add such directives.
     def render_zsh(self) -> str:
         script_name, script_path = self._get_script_name_and_path()
         aliases = [
+            script_name,
             self._quote_script_path_for_compdef(script_path),
             *self.option("alias"),
         ]

--- a/tests/commands/completion/fixtures/bash_with_space_in_script_name.txt
+++ b/tests/commands/completion/fixtures/bash_with_space_in_script_name.txt
@@ -1,0 +1,68 @@
+_my_function()
+{
+    local cur script coms opts com
+    COMPREPLY=()
+    _get_comp_words_by_ref -n : cur words
+
+    # for an alias, get the real script behind it
+    if [[ $(type -t ${words[0]}) == "alias" ]]; then
+        script=$(alias ${words[0]} | sed -E "s/alias ${words[0]}='(.*)'/\1/")
+    else
+        script=${words[0]}
+    fi
+
+    # lookup for command
+    for word in ${words[@]:1}; do
+        if [[ $word != -* ]]; then
+            com=$word
+            break
+        fi
+    done
+
+    # completing for an option
+    if [[ ${cur} == --* ]] ; then
+        opts="--ansi --help --no-ansi --no-interaction --quiet --verbose --version"
+
+        case "$com" in
+
+            (command:with:colons)
+            opts="${opts} --goodbye"
+            ;;
+
+            (hello)
+            opts="${opts} --dangerous-option --option-without-description"
+            ;;
+
+            (help)
+            opts="${opts} "
+            ;;
+
+            (list)
+            opts="${opts} "
+            ;;
+
+            ('spaced command')
+            opts="${opts} --goodbye"
+            ;;
+
+        esac
+
+        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+
+        return 0;
+    fi
+
+    # completing for a command
+    if [[ $cur == $com ]]; then
+        coms="command:with:colons hello help list 'spaced command'"
+
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+
+        return 0
+    fi
+}
+
+complete -o default -F _my_function script
+complete -o default -F _my_function '/path/with space/to/my/script'

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -62,4 +62,5 @@ _my_function()
 }
 
 _my_function "$@"
+compdef _my_function script
 compdef _my_function /path/to/my/script

--- a/tests/commands/completion/fixtures/zsh_with_space_in_script_name.txt
+++ b/tests/commands/completion/fixtures/zsh_with_space_in_script_name.txt
@@ -62,4 +62,5 @@ _my_function()
 }
 
 _my_function "$@"
+compdef _my_function script
 compdef _my_function '/path/with space/to/my/script'

--- a/tests/commands/completion/fixtures/zsh_with_space_in_script_name.txt
+++ b/tests/commands/completion/fixtures/zsh_with_space_in_script_name.txt
@@ -1,0 +1,65 @@
+#compdef script
+
+_my_function()
+{
+    local state com cur
+    local -a opts
+    local -a coms
+
+    cur=${words[${#words[@]}]}
+
+    # lookup for command
+    for word in ${words[@]:1}; do
+        if [[ $word != -* ]]; then
+            com=$word
+            break
+        fi
+    done
+
+    if [[ ${cur} == --* ]]; then
+        state="option"
+        opts+=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
+    elif [[ $cur == $com ]]; then
+        state="command"
+        coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "'spaced command':Command with space in name.")
+    fi
+
+    case $state in
+        (command)
+            _describe 'command' coms
+        ;;
+        (option)
+            case "$com" in
+
+            (command:with:colons)
+            opts+=("--goodbye")
+            ;;
+
+            (hello)
+            opts+=("--dangerous-option:This \$hould be \`escaped\`." "--option-without-description")
+            ;;
+
+            (help)
+            opts+=()
+            ;;
+
+            (list)
+            opts+=()
+            ;;
+
+            ('spaced command')
+            opts+=("--goodbye")
+            ;;
+
+            esac
+
+            _describe 'option' opts
+        ;;
+        *)
+            # fallback to file completion
+            _arguments '*:file:_files'
+    esac
+}
+
+_my_function "$@"
+compdef _my_function '/path/with space/to/my/script'

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -33,11 +33,20 @@ def test_invalid_shell() -> None:
 
 
 @pytest.mark.skipif(WINDOWS, reason="Only test linux shells")
-def test_bash(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    "script_path, output_fixture_filename",
+    [
+        ("/path/to/my/script", "bash.txt"),
+        ("/path/with space/to/my/script", "bash_with_space_in_script_name.txt"),
+    ],
+)
+def test_bash(
+    mocker: MockerFixture, script_path: str, output_fixture_filename: str
+) -> None:
     mocker.patch(
         "cleo.io.inputs.string_input.StringInput.script_name",
         new_callable=mocker.PropertyMock,
-        return_value="/path/to/my/script",
+        return_value=script_path,
     )
     mocker.patch(
         "cleo.commands.completions_command.CompletionsCommand._generate_function_name",
@@ -48,18 +57,31 @@ def test_bash(mocker: MockerFixture) -> None:
     tester = CommandTester(command)
     tester.execute("bash")
 
-    with open(os.path.join(os.path.dirname(__file__), "fixtures", "bash.txt")) as f:
+    fixture_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", output_fixture_filename
+    )
+
+    with open(fixture_path) as f:
         expected = f.read()
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")
 
 
 @pytest.mark.skipif(WINDOWS, reason="Only test linux shells")
-def test_zsh(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    "script_path, output_fixture_filename",
+    [
+        ("/path/to/my/script", "zsh.txt"),
+        ("/path/with space/to/my/script", "zsh_with_space_in_script_name.txt"),
+    ],
+)
+def test_zsh(
+    mocker: MockerFixture, script_path: str, output_fixture_filename: str
+) -> None:
     mocker.patch(
         "cleo.io.inputs.string_input.StringInput.script_name",
         new_callable=mocker.PropertyMock,
-        return_value="/path/to/my/script",
+        return_value=script_path,
     )
     mocker.patch(
         "cleo.commands.completions_command.CompletionsCommand._generate_function_name",
@@ -70,7 +92,9 @@ def test_zsh(mocker: MockerFixture) -> None:
     tester = CommandTester(command)
     tester.execute("zsh")
 
-    with open(os.path.join(os.path.dirname(__file__), "fixtures", "zsh.txt")) as f:
+    with open(
+        os.path.join(os.path.dirname(__file__), "fixtures", output_fixture_filename)
+    ) as f:
         expected = f.read()
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")


### PR DESCRIPTION
- Add PyCharm language injection comments
- feat: quote script name in completion function
- Add a zsh compdef for the bare script_name
- feat: Add flag to completions to set function name
